### PR TITLE
Add Shields.io badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Suggested use,
 `https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
-* `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20%23`)
-* `FIELD` = `global_rank` or `country_rank`
+* `FIELD` = `global_rank`, `country_rank` or `rating`
+* `TEXT` = `Rank%20`, country abbreviation (e.g., `US%20%23`) or `Rating%20`
 
 ### Pro Tip 💡
 Use this [JSON Formatter Chrome Extension](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en) to view in a structured format.

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Replace `<USERNAME>` with your username on that platform.
 
 #### <a href="https://codeforces.com/profile/abhijeet_ar"><img src="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
 `https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge`
+
 Suggested use,
 * `FIELD` = `rating`
 * `TEXT` = `Rating%20`
 
 #### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef"></a>
 `https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge`
+
 Suggested use,
 * `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20%23`)
 * `FIELD` = `global_rank` or `country_rank`

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ https://competitive-coding-api.herokuapp.com/api/codechef/abhijeet_ar
 
 Replace `<USERNAME>` with your username on that platform.
 
-#### <a href="https://codeforces.com/profile/abhijeet_ar"><img src="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
+#### <a href="https://codeforces.com/profile/abhijeet_ar"><img src="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces" title="abhijeet_ar's profile on Codeforces"></a>
 `https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
 * `FIELD` = `rating`
 * `TEXT` = `Rating%20`
 
-#### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef"></a>
+#### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef" title="radix28_numb's profile on CodeChef"></a>
 `https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://competitive-coding-api.herokuapp.com/api/codechef/abhijeet_ar
 
 Replace `<USERNAME>` with your username on that platform.
 
-#### <a href="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
+#### <a href="https://codeforces.com/profile/abhijeet_ar"><img src="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
 `https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge`
 Suggested use,
 * `FIELD` = `rating`

--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ https://competitive-coding-api.herokuapp.com/api/codechef/abhijeet_ar
 
 Replace `<USERNAME>` with your username on that platform.
 
-#### ![Codeforces static badge](https://img.shields.io/badge/Codeforces-Rating%20Unrated-informational?logo=codeforces&style=for-the-badge)
+#### <a href="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
 `https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge`
 Suggested use,
 * `FIELD` = `rating`
 * `TEXT` = `Rating%20`
 
-#### ![CodeChef static badge](https://img.shields.io/badge/CodeChef-Rank%20NA-informational?logo=codechef&style=for-the-badge&logoColor=f5f5dc&labelColor=7b5e47)
+#### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef"></a>
 `https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge`
 Suggested use,
-* `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20`)
+* `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20%23`)
 * `FIELD` = `global_rank` or `country_rank`
 
 ### Pro Tip 💡

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Replace `<USERNAME>` with your username on that platform.
 `https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
-* `FIELD` = `rating`
-* `TEXT` = `Rating%20`
+* `<FIELD>` = `rating`
+* `<TEXT>` = `Rating%20`
 
 #### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef" title="radix28_numb's profile on CodeChef"></a>
 `https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
-* `FIELD` = `global_rank`, `country_rank` or `rating`
-* `TEXT` = `Rank%20`, country abbreviation (e.g., `US%20%23`) or `Rating%20`
+* `<FIELD>` = `global_rank`, `country_rank` or `rating`
+* `<TEXT>` = `Rank%20`, country abbreviation (e.g., `US%20%23`) or `Rating%20`
 
 ### Pro Tip 💡
 Use this [JSON Formatter Chrome Extension](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en) to view in a structured format.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,25 @@ https://competitive-coding-api.herokuapp.com/api/
 ## Request Format
 https://competitive-coding-api.herokuapp.com/api/{platform_name}/{user_name}
 
-### Example
+### Example URL
 https://competitive-coding-api.herokuapp.com/api/codechef/abhijeet_ar
+
+### Example Badges
+[Shields](https://shields.io/) can create dynamically updated badges from a JSON source such as this API. More configuration options are also available in their section on [dynamic badges](https://shields.io/#dynamic-badge).
+
+Replace `<USERNAME>` with your username on that platform.
+
+#### ![Codeforces static badge](https://img.shields.io/badge/Codeforces-Rating%20Unrated-informational?logo=codeforces&style=for-the-badge)
+`https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge`
+Suggested use,
+* `FIELD` = `rating`
+* `TEXT` = `Rating%20`
+
+#### ![CodeChef static badge](https://img.shields.io/badge/CodeChef-Rank%20NA-informational?logo=codechef&style=for-the-badge&logoColor=f5f5dc&labelColor=7b5e47)
+`https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge`
+Suggested use,
+* `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20`)
+* `FIELD` = `global_rank` or `country_rank`
 
 ### Pro Tip 💡
 Use this [JSON Formatter Chrome Extension](https://chrome.google.com/webstore/detail/json-formatter/bcjindcccaagfpapjjmafapmmgkkhgoa?hl=en) to view in a structured format.

--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ https://competitive-coding-api.herokuapp.com/api/codechef/abhijeet_ar
 Replace `<USERNAME>` with your username on that platform.
 
 #### <a href="https://codeforces.com/profile/abhijeet_ar"><img src="https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/abhijeet_ar&query=%24.rating&prefix=Rating%20&style=for-the-badge&cacheSeconds=259200" alt="abhijeet_ar's profile on Codeforces"></a>
-`https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge`
+`https://img.shields.io/badge/dynamic/json?&color=1f8acb&logo=codeforces&label=Codeforces&url=https://competitive-coding-api.herokuapp.com/api/codeforces/<USERNAME>&query=%24.<FIELD>&prefix=<TEXT>&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
 * `FIELD` = `rating`
 * `TEXT` = `Rating%20`
 
 #### <a href="https://www.codechef.com/users/radix28_numb"><img src="https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.country_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/radix28_numb&prefix=US%20%23&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=259200" alt="radix28_numb's profile on CodeChef"></a>
-`https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge`
+`https://img.shields.io/badge/dynamic/json?label=CodeChef&query=%24.global_rank&url=https://competitive-coding-api.herokuapp.com/api/codechef/<USERNAME>&prefix=<TEXT>&logo=codechef&logoColor=f5f5dc&labelColor=7b5e47&style=for-the-badge&cacheSeconds=86400`
 
 Suggested use,
 * `TEXT` = `Rank%20` or country abbreviation (e.g., `US%20%23`)


### PR DESCRIPTION
Hello, first of all, _nice repository and thank you for your effort in creating it!_

I just thought I'd add this as a suggested use of the API.
For an "in-action" example, I added a CodeChef badge with my global ranking on my own GitHub profile https://github.com/k3KAW8Pnf7mkmdSMPHz27/ (under **hobbies**, sometimes it can take ≈ 5 s to load, probably if the cache is invalidated).
It mostly work if the cache lifetime value is high enough, occasionally it shows an error message instead of my rank 😬  

Some thing to note that you might want to change, or I can address them later,

1. The example images shown are not dynamic, but they can be made dynamic with a long HTTP cache lifetime. I can volunteer my account on the sites that I have, otherwise one can just pick anyone from top10 or a personal favourite competitive programmer 😛  (I'd go with Errichto based on his youtubes)
2. The example code should probably have a HTTP cache lifetime value as well. The one I have is updated once a day, which is much more frequent than I need for my occasional monthly long codechef challenge 😛  Feel free to suggest what you consider to be a reasonable refresh time and I'll add it to the "code" examples.
2. The badges/shields that I have not included does not have an icon on https://simpleicons.org/ . This is not a problem per say, as it is possible to use an image. I have not had time to do so. I can submit one/more PR whenever I have time to add more badges.
3. Leetcode is listed on simpleicons but when I were writing the changes I kept getting "internal server error" and I am not sure why. I did not have time to look into it. I can probably submit a PR for that as well at some point in the future. Unfortunately, time is a limited resource 😬 